### PR TITLE
Spaceクラスの構造を変更、SpaceRepositoryを実装

### DIFF
--- a/app/src/main/java/com/belltree/pomodoroshareapp/domain/models/Space.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/domain/models/Space.kt
@@ -18,6 +18,7 @@ enum class SpaceState {
     WAITING,
     WORKING,
     BREAK,
+    FINISHED
 }
 
 enum class TimerState {

--- a/app/src/main/java/com/belltree/pomodoroshareapp/domain/repository/SpaceRepository.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/domain/repository/SpaceRepository.kt
@@ -1,4 +1,29 @@
 package com.belltree.pomodoroshareapp.domain.repository
 
+import com.belltree.pomodoroshareapp.domain.models.Space
+import com.belltree.pomodoroshareapp.domain.models.SpaceState
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.tasks.await
+
 class SpaceRepository {
+    val db = Firebase.firestore
+
+    // まだ終了していない部屋の一覧をFirestoreから取得する(HomeViewModelで使用)
+    suspend fun getUnfinishedSpaces(): List<Space> {
+        val snapshot = db.collection("spaces")
+            .whereNotEqualTo("spaceState", SpaceState.FINISHED)
+            .get()
+            .await()
+        return snapshot.documents.mapNotNull { it.toObject(Space::class.java) }
+    }
+
+    // 新しい部屋を作成する(MakeSpaceViewModelで使用)
+    fun createSpace(space: Space) = db.collection("spaces").add(space)
+
+    // 部屋に入ったときに部屋の情報を取得する(SpaceViewModelで使用)
+    suspend fun getSpaceById(spaceId: String): Space? {
+        val snapshot = db.collection("spaces").document(spaceId).get().await()
+        return snapshot.toObject(Space::class.java)
+    }
 }


### PR DESCRIPTION
本来は部屋画面で定期的にFirestore側のデータをチェックしてタイマーを同期する処理が必要だと思うのですが、プロトタイプでまだ実装できていないためその部分は実装していません