### PR TITLE
totalStudyPointに応じてホーム画面のユーザーアイコンが装飾されるように変更

### DIFF
--- a/app/src/main/java/com/belltree/pomodoroshareapp/domain/models/User.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/domain/models/User.kt
@@ -16,7 +16,7 @@ data class User(
     */
     val totalStudyPoint: Long = 0,
     //フレームの種類
-    val rewardState: RewardState = RewardState.Bronze,
+    val rewardState: String = RewardState.Bronze.toString(),
     val userSpaceState: UserSpaceState = UserSpaceState.Exit
 )
 
@@ -26,6 +26,7 @@ enum class RewardState {
     Gold,
     Diamond,
 }
+
 enum class UserSpaceState {
     Use,
     Exit,

--- a/app/src/main/java/com/belltree/pomodoroshareapp/home/HomeScreen.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/home/HomeScreen.kt
@@ -1,126 +1,96 @@
 package com.belltree.pomodoroshareapp.home
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.People
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Contacts
-import androidx.compose.material.icons.filled.Groups
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.SignalCellularAlt
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.belltree.pomodoroshareapp.domain.models.Space
 import com.belltree.pomodoroshareapp.domain.models.SpaceState
 import com.belltree.pomodoroshareapp.ui.components.AppTopBar
-import kotlin.String
-import android.util.Log
-import androidx.activity.compose.BackHandler
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import com.belltree.pomodoroshareapp.Space.ConfirmDialog
-import androidx.compose.material.icons.filled.Add
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-	homeViewModel: HomeViewModel,
+    homeViewModel: HomeViewModel,
     onNavigateSettings: () -> Unit = {},
     onNavigateMakeSpace: () -> Unit = {},
     onNavigateRecord: () -> Unit = {},
-	onNavigateSpace: (String) -> Unit = {},
+    onNavigateSpace: (String) -> Unit = {},
 ) {
 
-	val spaces by homeViewModel.spaces.collectAsState()
-	val ownerName by homeViewModel.ownerName.collectAsState() //利用しているユーザー名を指す
-	val ownerPhotoUrl by homeViewModel.ownerPhotoUrl.collectAsState()
-	val isLoading by homeViewModel.isLoading.collectAsState()
-	var keyword by rememberSaveable { mutableStateOf("") }
-	var selectedLabel: SpaceState? by rememberSaveable { mutableStateOf<SpaceState?>(null) }
+    val spaces by homeViewModel.spaces.collectAsState()
+    val ownerName by homeViewModel.ownerName.collectAsState() //利用しているユーザー名を指す
+    val ownerPhotoUrl by homeViewModel.ownerPhotoUrl.collectAsState()
+    val ownerRewardState by homeViewModel.ownerRewardState.collectAsState()
+    val isLoading by homeViewModel.isLoading.collectAsState()
+    var keyword by rememberSaveable { mutableStateOf("") }
+    var selectedLabel: SpaceState? by rememberSaveable { mutableStateOf<SpaceState?>(null) }
     val recentlyLeftSpaceId by homeViewModel.recentlyLeftSpaceId.collectAsState()
     val pinnedSpace by homeViewModel.selectedSpace.collectAsState()
-	var showSpaceDialog by remember { mutableStateOf(false) }
-	var showIdDialog by remember {mutableStateOf(false)}
-	var inputId by rememberSaveable {mutableStateOf("")}
-	val listState = rememberLazyListState()
-	val filteredSpaces = spaces
-		.filter { space ->
-			keyword.isBlank() || space.spaceName.contains(keyword, ignoreCase = true) //==Query
-		}
-		.filter { space ->
-			selectedLabel == null || space.spaceState == selectedLabel//==Filter
-		}
-		//非公開部屋を非表示にする
-		.filter{ space ->
+    var showSpaceDialog by remember { mutableStateOf(false) }
+    var showIdDialog by remember { mutableStateOf(false) }
+    var inputId by rememberSaveable { mutableStateOf("") }
+    val listState = rememberLazyListState()
+    val filteredSpaces = spaces
+        .filter { space ->
+            keyword.isBlank() || space.spaceName.contains(keyword, ignoreCase = true) //==Query
+        }
+        .filter { space ->
+            selectedLabel == null || space.spaceState == selectedLabel//==Filter
+        }
+        //非公開部屋を非表示にする
+        .filter { space ->
             !space.isPrivate
-		}
-		.let { list ->
-			val idx = list.indexOfFirst { it.spaceId == recentlyLeftSpaceId }
-			if (idx >= 0) {
-				val target = list[idx]
-				listOf(target) + list.filterIndexed { i, _ -> i != idx }
-			} else list
-		}
-	LaunchedEffect(Unit) {
-		// 画面表示のたびに最新の未終了スペース一覧を取得
-		homeViewModel.load()
-		homeViewModel.loadOwner()
-	}
+        }
+        .let { list ->
+            val idx = list.indexOfFirst { it.spaceId == recentlyLeftSpaceId }
+            if (idx >= 0) {
+                val target = list[idx]
+                listOf(target) + list.filterIndexed { i, _ -> i != idx }
+            } else list
+        }
+    LaunchedEffect(Unit) {
+        // 画面表示のたびに最新の未終了スペース一覧を取得
+        homeViewModel.load()
+        homeViewModel.loadOwner()
+    }
 
-	LaunchedEffect(recentlyLeftSpaceId) {
-		// 退出直後にも一覧を再取得して先頭に並び替えられるようにする
-		homeViewModel.load()
-		// フィルターで非表示になっている可能性があるためクリアする
-		selectedLabel = null
-		// 検索キーワードで非表示になっている可能性があるためクリアする
-		keyword = ""
+    LaunchedEffect(recentlyLeftSpaceId) {
+        // 退出直後にも一覧を再取得して先頭に並び替えられるようにする
+        homeViewModel.load()
+        // フィルターで非表示になっている可能性があるためクリアする
+        selectedLabel = null
+        // 検索キーワードで非表示になっている可能性があるためクリアする
+        keyword = ""
         // 一覧に存在しない場合に備えて対象スペースを明示的に取得
         recentlyLeftSpaceId?.let { id ->
             val trimmed = id.trim()
@@ -129,77 +99,80 @@ fun HomeScreen(
                 homeViewModel.getSpaceById(trimmed)
             }
         }
-		// 一番上にスクロールしてハイライトを見せる
-		if (recentlyLeftSpaceId != null && filteredSpaces.isNotEmpty()) {
-			listState.scrollToItem(0)
-		}
-	}
-	Scaffold(
-		topBar = {
-			AppTopBar(
-				title = "ルーム一覧",
-				searchBar = {
-					SearchBar(
-						keyword = keyword,
-						onKeywordChange = { keyword = it },
-				)},
-				avatarUrl = ownerPhotoUrl.takeIf { it.isNotBlank() },
-				onNavigationClick = onNavigateRecord,
-				additionalNavigationIcons = listOf(
-					Icons.Filled.SignalCellularAlt to onNavigateRecord,
-					Icons.Filled.Search to {showIdDialog = true}
-				),
-				onAvatarClick = onNavigateSettings
-			)
-		},
-		floatingActionButton = {
-			FloatingActionButton(
-				onClick = { onNavigateMakeSpace() },
-				containerColor = Color(0xFFE76D48),
-				modifier = Modifier.size(56.dp),
-				shape = CircleShape
-			) {
-				Icon(
-					imageVector = Icons.Filled.Add,
-					contentDescription = "Create Room",
-					tint = Color(0xFFBEDC53)
-				)
-			}
-		}
-	) { innerPadding ->
-		Column(
-			modifier = Modifier
+        // 一番上にスクロールしてハイライトを見せる
+        if (recentlyLeftSpaceId != null && filteredSpaces.isNotEmpty()) {
+            listState.scrollToItem(0)
+        }
+    }
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = "ルーム一覧",
+                searchBar = {
+                    SearchBar(
+                        keyword = keyword,
+                        onKeywordChange = { keyword = it },
+                    )
+                },
+                avatarUrl = ownerPhotoUrl.takeIf { it.isNotBlank() },
+                userRewardState = ownerRewardState.toString(),
+                onNavigationClick = onNavigateRecord,
+                additionalNavigationIcons = listOf(
+                    Icons.Filled.SignalCellularAlt to onNavigateRecord,
+                    Icons.Filled.Search to { showIdDialog = true }
+                ),
+                onAvatarClick = onNavigateSettings
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { onNavigateMakeSpace() },
+                containerColor = Color(0xFFE76D48),
+                modifier = Modifier.size(56.dp),
+                shape = CircleShape
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = "Create Room",
+                    tint = Color(0xFFBEDC53)
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
 				.fillMaxSize()
 				.padding(innerPadding)
 				.background(Color.White)//指定しないとスマホデフォルトの色と混ざる
-		) {
-			LabelBar(
-				selectedLabel = selectedLabel,
-				onSelectedLabelChange = { selectedLabel = it },
-				modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-			)
-			if (isLoading) {
-				Box(
-					modifier = Modifier.fillMaxSize(),
-					contentAlignment = Alignment.Center
-				) {
-					CircularProgressIndicator()
-				}
-			} else {
+        ) {
+            LabelBar(
+                selectedLabel = selectedLabel,
+                onSelectedLabelChange = { selectedLabel = it },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
                 LazyColumn(
-					modifier = Modifier.fillMaxSize(),
-					contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-					verticalArrangement = Arrangement.spacedBy(8.dp),
-					state = listState
-				) {
-					item() {
-						HomeGreetingSection(
-							userName = ownerName,
-							modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-						)
-					}
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    state = listState
+                ) {
+                    item() {
+                        HomeGreetingSection(
+                            userName = ownerName,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
                     // 退出した部屋を最上部に固定表示（一覧に無い場合でも表示）
-                    val topSpace = filteredSpaces.firstOrNull { it.spaceId == recentlyLeftSpaceId } ?: pinnedSpace
+                    val topSpace = filteredSpaces.firstOrNull { it.spaceId == recentlyLeftSpaceId }
+                        ?: pinnedSpace
                     if (topSpace != null) {
                         item("pinned-${'$'}{topSpace.spaceId}") {
                             HomeRow(
@@ -210,52 +183,54 @@ fun HomeScreen(
                             )
                         }
                     }
-                    val rest = topSpace?.let { pinned -> filteredSpaces
-						.filter { it.spaceId != pinned.spaceId } } ?: filteredSpaces
-						.filter { it.isPrivate == false}//非公開部屋を非表示にする
+                    val rest = topSpace?.let { pinned ->
+                        filteredSpaces
+                            .filter { it.spaceId != pinned.spaceId }
+                    } ?: filteredSpaces
+                        .filter { it.isPrivate == false }//非公開部屋を非表示にする
                     items(rest) { item ->
-						HomeRow(
-							space = item,
-							onSpaceClick = { id -> onNavigateSpace(id) },
-							modifier = Modifier.fillMaxWidth(),
-							highlight = item.spaceId == recentlyLeftSpaceId
-						)
-					}
-				}
-			}
-		}
-		if(showIdDialog){
+                        HomeRow(
+                            space = item,
+                            onSpaceClick = { id -> onNavigateSpace(id) },
+                            modifier = Modifier.fillMaxWidth(),
+                            highlight = item.spaceId == recentlyLeftSpaceId
+                        )
+                    }
+                }
+            }
+        }
+        if (showIdDialog) {
             InputIDDialog(
-				modifier = modifier,
+                modifier = modifier,
                 onDismiss = { showIdDialog = false },
                 onConfirm = {
                     showIdDialog = false
-					showSpaceDialog = true
+                    showSpaceDialog = true
                 },
-                onInputIdChange = {inputId = it},
+                onInputIdChange = { inputId = it },
                 inputId = inputId,
             )
-		}
+        }
 
-		if (showSpaceDialog) {
+        if (showSpaceDialog) {
             LaunchedEffect(showSpaceDialog, inputId) {
-				// ダイアログ表示時に対象スペースを取得（suspend 呼び出しはここで行う）
+                // ダイアログ表示時に対象スペースを取得（suspend 呼び出しはここで行う）
                 val trimmed = inputId.trim()
                 if (trimmed.isNotEmpty()) {
                     homeViewModel.getSpaceById(trimmed)
                 }
-			}
-			pinnedSpace?.let { sp ->
-				ShowSpaceDialog(
-					onDismiss = { showSpaceDialog = false },
-					onConfirm = { id ->
-						showSpaceDialog = false
-						onNavigateSpace(id)
-					},
-					space = sp
-				)
-			}
-		}
-	}
+            }
+            pinnedSpace?.let { sp ->
+                ShowSpaceDialog(
+                    onDismiss = { showSpaceDialog = false },
+                    onConfirm = { id ->
+                        showSpaceDialog = false
+                        onNavigateSpace(id)
+                    },
+                    space = sp
+                )
+            }
+        }
+    }
 }
 

--- a/app/src/main/java/com/belltree/pomodoroshareapp/home/HomeViewModel.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.belltree.pomodoroshareapp.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.belltree.pomodoroshareapp.domain.models.RewardState
 import com.belltree.pomodoroshareapp.domain.models.Space
 import com.belltree.pomodoroshareapp.domain.models.User
 import com.belltree.pomodoroshareapp.domain.repository.SpaceRepository
@@ -28,6 +29,8 @@ class HomeViewModel @Inject constructor(
     val ownerName: StateFlow<String> = _ownerName
     private val _ownerPhotoUrl = MutableStateFlow<String>("")
     val ownerPhotoUrl: StateFlow<String> = _ownerPhotoUrl
+    private val _ownerRewardState = MutableStateFlow<String>(RewardState.Bronze.toString())
+    val ownerRewardState: StateFlow<String> = _ownerRewardState
     private val _spaces = MutableStateFlow<List<Space>>(emptyList())
     val spaces: StateFlow<List<Space>> = _spaces
 
@@ -79,6 +82,7 @@ class HomeViewModel @Inject constructor(
             val u = userRepository.getUserById(userId)
             _ownerName.value = u?.userName ?: "Guest User"
             _ownerPhotoUrl.value = u?.photoUrl ?: ""
+            _ownerRewardState.value = u?.rewardState.toString() ?: RewardState.Bronze.toString()
         }
     }
 

--- a/app/src/main/java/com/belltree/pomodoroshareapp/home/UserIconWithFrame.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/home/UserIconWithFrame.kt
@@ -1,0 +1,77 @@
+package com.belltree.pomodoroshareapp.home
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.belltree.pomodoroshareapp.ui.theme.PomodoroAppColors
+
+@Composable
+fun UserIconWithFrame(
+    userImageURL: String?,
+    rewardState: String?,
+    modifier: Modifier = Modifier
+) {
+    val borderBrush = when (rewardState) {
+        "Gold" -> Brush.linearGradient(
+            colors = listOf(Color(0xFFFFD700), Color(0xFFFFA500)) // 金
+        )
+
+        "Silver" -> Brush.linearGradient(
+            colors = listOf(Color.LightGray, Color.White) // 銀
+        )
+
+        "Bronze" -> Brush.linearGradient(
+            colors = listOf(Color(0xFFCD7F32), Color(0xFF8B4513)) // 銅
+        )
+
+        "Diamond" -> Brush.linearGradient(
+            colors = listOf(Color.Cyan, Color(0xFF00FFFF), Color(0xFF87CEFA)) // ダイヤ
+        )
+
+        else -> Brush.linearGradient(listOf(Color.Gray, Color.DarkGray)) // デフォルト
+    }
+
+    Box(
+        modifier = modifier
+            .size(100.dp)
+            .clip(CircleShape)
+            .border(BorderStroke(6.dp, borderBrush), CircleShape), // 枠を描画
+        contentAlignment = Alignment.Center
+    ) {
+        if (userImageURL.isNullOrEmpty()) {
+            Icon(
+                imageVector = Icons.Default.Person,
+                contentDescription = "User",
+                tint = PomodoroAppColors.LightGray,
+                modifier = Modifier
+                    .size(90.dp)
+                    .clip(CircleShape)
+            )
+        } else {
+            AsyncImage(
+                model = userImageURL,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(90.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/belltree/pomodoroshareapp/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/belltree/pomodoroshareapp/ui/components/AppTopBar.kt
@@ -3,8 +3,6 @@ package com.belltree.pomodoroshareapp.ui.components
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -17,11 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import com.belltree.pomodoroshareapp.home.UserIconWithFrame
 import com.belltree.pomodoroshareapp.ui.theme.PomodoroAppColors
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,6 +29,7 @@ fun AppTopBar(
     rightActionIcons: List<Pair<ImageVector, () -> Unit>> = emptyList(),
     additionalNavigationIcons: List<Pair<ImageVector, () -> Unit>> = emptyList(),
     avatarUrl: String? = null,
+    userRewardState: String? = null,
     onAvatarClick: (() -> Unit)? = null,
     searchBar: (@Composable () -> Unit)? = null,
 ) {
@@ -72,16 +69,23 @@ fun AppTopBar(
         actions = {
             if (!avatarUrl.isNullOrBlank()) {
                 IconButton(onClick = { onAvatarClick?.invoke() }) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(avatarUrl)
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = "Avatar",
+                    UserIconWithFrame(
+                        userImageURL = avatarUrl,
+                        rewardState = userRewardState.toString(),
                         modifier = Modifier
                             .size(32.dp)
                             .clip(CircleShape)
                     )
+//                    AsyncImage(
+//                        model = ImageRequest.Builder(LocalContext.current)
+//                            .data(avatarUrl)
+//                            .crossfade(true)
+//                            .build(),
+//                        contentDescription = "Avatar",
+//                        modifier = Modifier
+//                            .size(32.dp)
+//                            .clip(CircleShape)
+//                    )
                 }
             } else if (title == "ルーム一覧") {//ホーム画面のみデフォルトアイコンを表示
                 IconButton(
@@ -90,10 +94,17 @@ fun AppTopBar(
                         .clip(CircleShape),
                     onClick = { onAvatarClick?.invoke() }
                 ) {
-                    Icon(
-                        Icons.Filled.Person,
-                        contentDescription = "Avatar",
-                        tint = PomodoroAppColors.DarkGray
+//                    Icon(
+//                        Icons.Filled.Person,
+//                        contentDescription = "Avatar",
+//                        tint = PomodoroAppColors.DarkGray
+//                    )
+                    UserIconWithFrame(
+                        userImageURL = null,
+                        rewardState = userRewardState.toString(),
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
                     )
                 }
             }


### PR DESCRIPTION
UserクラスのrewardStateですが、Firestoreだと独自クラスが保存できないためString型に変えています
銀→金→ダイヤ→銅
<img width="270" height="585" alt="Screenshot_20250926-191550" src="https://github.com/user-attachments/assets/9672d191-65c3-4176-9500-01d24f600f89" />
<img width="270" height="585" alt="Screenshot_20250926-191644" src="https://github.com/user-attachments/assets/8c3be657-22d1-4a61-949d-1fecefb39e05" />
<img width="270" height="585" alt="Screenshot_20250926-191953" src="https://github.com/user-attachments/assets/185063a7-117e-408e-91f2-1b538380d937" />
<img width="270" height="585" alt="Screenshot_20250926-192156" src="https://github.com/user-attachments/assets/0cd8c799-f840-4d47-a90d-aaa83009c37b" />
